### PR TITLE
fix (yandex_cloud_api): rm (yandex.cloud.api.tools.field) as unknow o…

### DIFF
--- a/yandex/cloud/ai/stt/v2/stt_service.proto
+++ b/yandex/cloud/ai/stt/v2/stt_service.proto
@@ -102,7 +102,7 @@ message SpeechRecognitionResult {
 
 message SpeechRecognitionAlternative {
   string text = 1;
-  float confidence = 2 [(yandex.cloud.api.tools.field).lint_skip.float_type = true];
+  float confidence = 2;
   repeated WordInfo words = 3;
 }
 
@@ -110,5 +110,5 @@ message WordInfo {
   google.protobuf.Duration start_time = 1;
   google.protobuf.Duration end_time = 2;
   string word = 3;
-  float confidence = 4 [(yandex.cloud.api.tools.field).lint_skip.float_type = true];
+  float confidence = 4;
 }


### PR DESCRIPTION
When i was passing your [guide](https://cloud.yandex.com/docs/speechkit/stt/streaming) in the second step:
`
python -m grpc_tools.protoc -I . -I third_party/googleapis --python_out=output --grpc_python_out=output google/api/http.proto google/api/annotations.proto yandex/cloud/api/operation.proto google/rpc/status.proto yandex/cloud/operation/operation.proto yandex/cloud/ai/stt/v2/stt_service.proto
`
I got an exception, see below:
`
yandex/cloud/ai/stt/v2/stt_service.proto:105:25: Option "(yandex.cloud.api.tools.field)" unknown. Ensure that your proto definition file imports the proto which defines the option.
yandex/cloud/ai/stt/v2/stt_service.proto:113:25: Option "(yandex.cloud.api.tools.field)" unknown. Ensure that your proto definition file imports the proto which defines the option.
`
After deleting these lines everything works.