### PR TITLE
Fix wrong description

### DIFF
--- a/yandex/cloud/kms/v1/symmetric_crypto_service.proto
+++ b/yandex/cloud/kms/v1/symmetric_crypto_service.proto
@@ -77,7 +77,6 @@ message SymmetricDecryptRequest {
   bytes aad_context = 2 [(length) = "<=8192"];
 
   // Ciphertext to be decrypted.
-  // Should be encoded with base64.
   bytes ciphertext = 3 [(required) = true];
 }
 


### PR DESCRIPTION
Remove base64 requirements for ciphertext in SymmetricDecryptRequest.

When I submit ciphertext  encoded in base64, I get an error message
```
rpc error: code = InvalidArgument desc = Bad ciphertext
```

In raw format, after  - OK

Full code

```

type YCKMS struct {
	sdk   *ycsdk.SDK
	keyID string
}

func New(sdk *ycsdk.SDK, keyID string) KMS {
	return &YCKMS{sdk: sdk, keyID: keyID}
}

func (s *YCKMS) Encrypt(aadContext string, plaintext string) (keyID string, versionID string, ciphertext []byte, err error) {
	aadContextBuf := make([]byte, base64.RawStdEncoding.EncodedLen(len([]byte(aadContext))))
	plaintextBuf := make([]byte, base64.RawStdEncoding.EncodedLen(len(plaintext)))

	base64.RawStdEncoding.Encode(aadContextBuf, []byte(aadContext))
	base64.RawStdEncoding.Encode(plaintextBuf, []byte(plaintext))

	result, err := s.sdk.KMSCrypto().SymmetricCrypto().Encrypt(context.Background(), &kms.SymmetricEncryptRequest{
		KeyId:      s.keyID,
		AadContext: aadContextBuf,
		Plaintext:  plaintextBuf,
	})
	if err != nil {
		return "", "", nil, err
	}

	return result.KeyId, result.VersionId, result.Ciphertext, nil
}

func (s *YCKMS) Decrypt(aadContext string, ciphertext []byte) ([]byte, error) {
	aadContextBuf := make([]byte, base64.RawStdEncoding.EncodedLen(len([]byte(aadContext))))

	base64.RawStdEncoding.Encode(aadContextBuf, []byte(aadContext))

	result, err := s.sdk.KMSCrypto().SymmetricCrypto().Decrypt(context.Background(), &kms.SymmetricDecryptRequest{
		KeyId:      s.keyID,
		AadContext: aadContextBuf,
		Ciphertext: ciphertext,
	})
	if err != nil {
		return nil, err
	}

	return result.Plaintext, nil
}
```