### PR TITLE
chore(compute/v1): add missing AutoHealingPolicy in create/update requests

### DIFF
--- a/yandex/cloud/compute/v1/instancegroup/instance_group_service.proto
+++ b/yandex/cloud/compute/v1/instancegroup/instance_group_service.proto
@@ -331,6 +331,9 @@ message CreateInstanceGroupRequest {
   // If specified, an Application Load Balancer target group containing all instances from the instance group will be created
   // and attributed to the instance group.
   ApplicationLoadBalancerSpec application_load_balancer_spec = 15;
+
+  // AutoHealingPolicy policy of the instance group.
+  AutoHealingPolicy auto_healing_policy = 16 [(required) = true];
 }
 
 message CreateInstanceGroupFromYamlRequest {
@@ -412,6 +415,9 @@ message UpdateInstanceGroupRequest {
   // Settings for balancing load between instances via [Application Load Balancer](/docs/application-load-balancer/concepts)
   // (OSI model layer 7).
   ApplicationLoadBalancerSpec application_load_balancer_spec = 17;
+
+  // AutoHealingPolicy policy of the instance group.
+  AutoHealingPolicy auto_healing_policy = 18 [(required) = true];
 }
 
 message UpdateInstanceGroupFromYamlRequest {


### PR DESCRIPTION
While exploring terraform provider, I found that there is no [auto_healing_policy](https://yandex.cloud/ru/docs/compute/concepts/instance-groups/policies/healing-policy) field in [yandex_compute_instance_group](https://terraform-provider.yandexcloud.net/Resources/compute_instance_group). The provider uses an [CreateInstanceGroupRequest](https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/resource_yandex_compute_instance_group.go#L1497) and an [UpdateInstanceGroupRequest](https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/resource_yandex_compute_instance_group.go#L1574C24-L1574C50) from [github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1/instancegroup](https://github.com/yandex-cloud/go-genproto/blob/master/yandex/cloud/compute/v1/instancegroup/instance_group_service.pb.go). As I understand it, that code was generated from Protobuf structures in this repository. So, I added these missing fields to update terraform provider after these changes are merged.

The [yandex_kubernetes_node_group](https://terraform-provider.yandexcloud.net/Resources/kubernetes_node_group) has the same problem, I think. [auto_healing_policy](https://yandex.cloud/ru/docs/compute/concepts/instance-groups/specification#fields) is missing, while other policies are present. But these are different objects, although after creating a node group, a instance group will also be created with a managed label (managed-kubernetes-node-group-id). I can suggest that the `/managed-kubernetes/v1/nodeGroups` API passes some values to `/compute/v1/instanceGroups`. If you know where I can create a ticket to the Yandex Cloud team with a request to support auto_healing_policy in the node group API, I would be glad to know.